### PR TITLE
Add start screen with start button

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,7 +1,15 @@
     document.addEventListener('DOMContentLoaded', () => {
 
-        const canvas = document.getElementById('gameCanvas');
-        const ctx = canvas.getContext('2d');
+        const menu = document.getElementById('startScreen');
+        const startButton = document.getElementById('startButton');
+        startButton.addEventListener('click', () => {
+            menu.style.display = 'none';
+            initGame();
+        });
+
+        function initGame() {
+            const canvas = document.getElementById('gameCanvas');
+            const ctx = canvas.getContext('2d');
 
         // --- Matter.js Модули ---
         const Engine = Matter.Engine; const World = Matter.World; const Bodies = Matter.Bodies;
@@ -208,4 +216,5 @@
         }
 
         requestAnimationFrame(gameLoop);
+        }
     });

--- a/index.html
+++ b/index.html
@@ -8,7 +8,10 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/matter-js/0.19.0/matter.min.js"></script>
 </head>
 <body>
-<canvas id="gameCanvas" width="800" height="600"></canvas>
-<script src="game.js"></script>
+  <div id="startScreen" class="start-screen">
+    <button id="startButton">Start Game</button>
+  </div>
+  <canvas id="gameCanvas" width="800" height="600"></canvas>
+  <script src="game.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -16,3 +16,22 @@ canvas {
   background-color: #e0e6eb;
   display: block;
 }
+
+.start-screen {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+}
+
+#startButton {
+  padding: 10px 20px;
+  font-size: 1.2rem;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- add a start screen overlay to `index.html`
- style the new overlay in `styles.css`
- delay game start until button click in `game.js`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844005a5f7c8322a8b0af0245936e8a