### PR TITLE
Add mode selector and optional bot AI

### DIFF
--- a/game.js
+++ b/game.js
@@ -2,17 +2,28 @@ import { createPlatformData, getPlatformCoords } from './platforms.js';
 import { initControls, handleInput } from './controls.js';
 import { Engine, World, Bodies, Body, initPhysics, setupCollisionEvents } from "./physics.js";
 import { drawParallaxBackground, drawPlatforms, drawDecorations, drawPlayer, drawFlash, updateCamera } from './render.js';
+import { initGame, isSinglePlayer } from './initGame.js';
+import { updateBotAI } from './botAI.js';
 
     document.addEventListener('DOMContentLoaded', () => {
 
         const menu = document.getElementById('startScreen');
-        const startButton = document.getElementById('startButton');
-        startButton.addEventListener('click', () => {
+        const singleButton = document.getElementById('singleButton');
+        const twoButton = document.getElementById('twoButton');
+
+        singleButton.addEventListener('click', () => {
             menu.style.display = 'none';
-            initGame();
+            initGame('single');
+            startGame();
         });
 
-        function initGame() {
+        twoButton.addEventListener('click', () => {
+            menu.style.display = 'none';
+            initGame('two');
+            startGame();
+        });
+
+        function startGame() {
             const canvas = document.getElementById('gameCanvas');
             const ctx = canvas.getContext('2d');
 
@@ -96,6 +107,14 @@ import { drawParallaxBackground, drawPlatforms, drawDecorations, drawPlayer, dra
                 const data = playerBody.renderData; if (data.tagTimer > 0) { data.tagTimer -= dt; if (data.tagTimer < 0) { data.tagTimer = 0; } }
             });
             handleInput({ playerBodies, Body, moveSpeed, jumpStrength, accelerationFactor, decelerationFactor, jumpVelocityThreshold });
+            if (isSinglePlayer) {
+                updateBotAI(playerBodies[1], playerBodies[0], {
+                    moveSpeed,
+                    jumpStrength,
+                    accelerationFactor,
+                    jumpVelocityThreshold
+                });
+            }
             Engine.update(engine, dt); updateCamera(camera, canvasWidth, canvasHeight, worldWidth, worldHeight, zoomPadding, minZoom, maxZoom, zoomLerpFactor, cameraLerpFactor, playerBodies);
             ctx.fillStyle = pageBackgroundColor; ctx.fillRect(0, 0, canvasWidth, canvasHeight); ctx.save();
             ctx.translate(canvasWidth / 2, canvasHeight / 2); ctx.scale(camera.zoom, camera.zoom); ctx.translate(-camera.focusX, -camera.focusY);

--- a/index.html
+++ b/index.html
@@ -9,7 +9,8 @@
 </head>
 <body>
   <div id="startScreen" class="start-screen">
-    <button id="startButton">Start Game</button>
+    <button id="singleButton" class="mode-button">1 Player</button>
+    <button id="twoButton" class="mode-button">2 Players</button>
   </div>
   <canvas id="gameCanvas" width="800" height="600"></canvas>
   <script type="module" src="game.js"></script>

--- a/initGame.js
+++ b/initGame.js
@@ -1,0 +1,9 @@
+export let isSinglePlayer = false;
+
+export function initGame(mode) {
+  if (mode === 'single') {
+    isSinglePlayer = true;
+  } else {
+    isSinglePlayer = false;
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -30,8 +30,9 @@ canvas {
   flex-direction: column;
 }
 
-#startButton {
+.start-screen button {
   padding: 10px 20px;
   font-size: 1.2rem;
   cursor: pointer;
+  margin: 5px;
 }


### PR DESCRIPTION
## Summary
- add "1 Player" and "2 Players" buttons
- style start screen buttons
- store selected mode in `initGame.js`
- launch game using chosen mode and run bot AI only in single player mode

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6844273fc8a08322ad4182fa4c60074f