### PR TITLE
Unify player and bot movement

### DIFF
--- a/controls.js
+++ b/controls.js
@@ -9,41 +9,23 @@ export function initControls() {
     });
 }
 
-export function handleInput({ playerBodies, Body, moveSpeed, jumpStrength, accelerationFactor, decelerationFactor, jumpVelocityThreshold }) {
+import { applyMovement } from './movementController.js';
+
+export function handleInput({ playerBodies, Body, moveSpeed, jumpStrength, accelerationFactor, decelerationFactor, jumpVelocityThreshold, dt }) {
     playerBodies.forEach(playerBody => {
         const data = playerBody.renderData;
-        const currentVelocity = playerBody.velocity;
-        let targetVx = 0;
-        data.isMovingHorizontally = false;
+        const input = {
+            moveLeft: !!keysPressed[data.controls.left],
+            moveRight: !!keysPressed[data.controls.right],
+            jumpPressed: !!keysPressed[data.controls.up]
+        };
 
-        if (keysPressed[data.controls.left]) {
-            targetVx = -moveSpeed;
-            data.facingDirection = 'left';
-            data.isMovingHorizontally = true;
-        }
-        if (keysPressed[data.controls.right]) {
-            targetVx = moveSpeed;
-            data.facingDirection = 'right';
-            data.isMovingHorizontally = true;
-        }
-
-        let newVx;
-        if (targetVx !== 0) {
-            newVx = currentVelocity.x + (targetVx - currentVelocity.x) * accelerationFactor;
-        } else {
-            newVx = currentVelocity.x + (targetVx - currentVelocity.x) * decelerationFactor;
-        }
-
-        Body.setVelocity(playerBody, { x: newVx, y: currentVelocity.y });
-
-        if (keysPressed[data.controls.up]) {
-            if (data.isOnGround && !data.hasJumpedThisPress && Math.abs(currentVelocity.y) < jumpVelocityThreshold) {
-                Body.setVelocity(playerBody, { x: playerBody.velocity.x, y: -jumpStrength });
-                data.isOnGround = false;
-                data.hasJumpedThisPress = true;
-            }
-        } else {
-            data.hasJumpedThisPress = false;
-        }
+        applyMovement(
+            playerBody,
+            input,
+            Body,
+            { moveSpeed, jumpStrength, accelerationFactor, decelerationFactor, jumpVelocityThreshold },
+            dt
+        );
     });
 }

--- a/game.js
+++ b/game.js
@@ -106,14 +106,15 @@ import { updateBotAI } from './botAI.js';
             playerBodies.forEach(playerBody => {
                 const data = playerBody.renderData; if (data.tagTimer > 0) { data.tagTimer -= dt; if (data.tagTimer < 0) { data.tagTimer = 0; } }
             });
-            handleInput({ playerBodies, Body, moveSpeed, jumpStrength, accelerationFactor, decelerationFactor, jumpVelocityThreshold });
+            handleInput({ playerBodies, Body, moveSpeed, jumpStrength, accelerationFactor, decelerationFactor, jumpVelocityThreshold, dt });
             if (isSinglePlayer) {
                 updateBotAI(playerBodies[1], playerBodies[0], {
                     moveSpeed,
                     jumpStrength,
                     accelerationFactor,
+                    decelerationFactor,
                     jumpVelocityThreshold
-                });
+                }, dt);
             }
             Engine.update(engine, dt); updateCamera(camera, canvasWidth, canvasHeight, worldWidth, worldHeight, zoomPadding, minZoom, maxZoom, zoomLerpFactor, cameraLerpFactor, playerBodies);
             ctx.fillStyle = pageBackgroundColor; ctx.fillRect(0, 0, canvasWidth, canvasHeight); ctx.save();

--- a/movementController.js
+++ b/movementController.js
@@ -1,0 +1,36 @@
+export function applyMovement(playerBody, input, Body, config, dt) {
+    const { moveSpeed, jumpStrength, accelerationFactor, decelerationFactor, jumpVelocityThreshold } = config;
+    const data = playerBody.renderData;
+    let targetVx = 0;
+    data.isMovingHorizontally = false;
+
+    if (input.moveLeft) {
+        targetVx = -moveSpeed;
+        data.facingDirection = 'left';
+        data.isMovingHorizontally = true;
+    }
+    if (input.moveRight) {
+        targetVx = moveSpeed;
+        data.facingDirection = 'right';
+        data.isMovingHorizontally = true;
+    }
+
+    const currentVx = playerBody.velocity.x;
+    let newVx;
+    if (targetVx !== 0) {
+        newVx = currentVx + (targetVx - currentVx) * accelerationFactor;
+    } else {
+        newVx = currentVx + (targetVx - currentVx) * decelerationFactor;
+    }
+    Body.setVelocity(playerBody, { x: newVx, y: playerBody.velocity.y });
+
+    if (input.jumpPressed) {
+        if (data.isOnGround && !data.hasJumpedThisPress && Math.abs(playerBody.velocity.y) < jumpVelocityThreshold) {
+            Body.setVelocity(playerBody, { x: playerBody.velocity.x, y: -jumpStrength });
+            data.isOnGround = false;
+            data.hasJumpedThisPress = true;
+        }
+    } else {
+        data.hasJumpedThisPress = false;
+    }
+}


### PR DESCRIPTION
## Summary
- add shared `movementController` for movement/jumping
- update keyboard handler to use new controller
- refactor bot AI to issue movement commands
- pass `dt` to input and AI handlers for consistent timing

## Testing
- `node --check movementController.js`
- `node --check controls.js`
- `node --check botAI.js`
- `node --check game.js`

------
https://chatgpt.com/codex/tasks/task_e_684431111a248322b16b7dc36b16a73c