### PR TITLE
Fix bot acceleration in single-player mode

### DIFF
--- a/controls.js
+++ b/controls.js
@@ -10,9 +10,12 @@ export function initControls() {
 }
 
 import { applyMovement } from './movementController.js';
+import { isSinglePlayer } from './initGame.js';
 
 export function handleInput({ playerBodies, Body, moveSpeed, jumpStrength, accelerationFactor, decelerationFactor, jumpVelocityThreshold, dt }) {
     playerBodies.forEach(playerBody => {
+        if (isSinglePlayer && playerBody.renderData.id === 1) return;
+
         const data = playerBody.renderData;
         const input = {
             moveLeft: !!keysPressed[data.controls.left],


### PR DESCRIPTION
## Summary
- prevent control handling for the bot when running in single-player mode

## Testing
- `node -e "require('./controls.js')"`

------
https://chatgpt.com/codex/tasks/task_e_684441ce522c832295c1e8333aa5d1b6