### PR TITLE
Add configurable bot AI params

### DIFF
--- a/botAI.js
+++ b/botAI.js
@@ -2,7 +2,18 @@ import { Body } from './physics.js';
 import { applyMovement } from './movementController.js';
 
 export function updateBotAI(botBody, playerBody, config, dt) {
-    const { moveSpeed, jumpStrength, accelerationFactor, decelerationFactor, jumpVelocityThreshold } = config;
+    const {
+        moveSpeed,
+        jumpStrength,
+        accelerationFactor,
+        decelerationFactor,
+        jumpVelocityThreshold,
+        chaseDistance,
+        jumpHeight,
+        jumpRange,
+        stuckDistance,
+        stuckTime
+    } = config;
 
     if (!botBody.renderData.aiState) {
         botBody.renderData.aiState = {
@@ -19,22 +30,22 @@ export function updateBotAI(botBody, playerBody, config, dt) {
     const dx = playerBody.position.x - botBody.position.x;
     const dy = playerBody.position.y - botBody.position.y;
 
-    if (Math.abs(dx) > 2) {
+    if (Math.abs(dx) > chaseDistance) {
         if (dx < 0) input.moveLeft = true;
         else input.moveRight = true;
     }
 
     const horizontalDistance = Math.abs(dx);
-    const shouldJump = dy < -20 && horizontalDistance < 200;
+    const shouldJump = dy < -jumpHeight && horizontalDistance < jumpRange;
 
-    const isStuck = (Math.abs(botBody.position.x - ai.lastPosX) < 1) && (now - ai.stuckTime > 500);
+    const isStuck = (Math.abs(botBody.position.x - ai.lastPosX) < stuckDistance) && (now - ai.stuckTime > stuckTime);
 
     if ((shouldJump || isStuck) && botBody.renderData.isOnGround && Math.abs(botBody.velocity.y) < jumpVelocityThreshold) {
         input.jumpPressed = true;
         ai.stuckTime = now;
     }
 
-    if (Math.abs(botBody.position.x - ai.lastPosX) >= 1) {
+    if (Math.abs(botBody.position.x - ai.lastPosX) >= stuckDistance) {
         ai.stuckTime = now;
     }
 

--- a/game.js
+++ b/game.js
@@ -48,6 +48,13 @@ import { updateBotAI } from './botAI.js';
         const accelerationFactor = 0.1; // Коэффициент ускорения (0.0 до 1.0)
         const decelerationFactor = 0.15; // Коэффициент замедления (0.0 до 1.0)
 
+        // --- Параметры ИИ бота ---
+        const chaseDistance = 2;   // Минимальная дистанция для начала преследования
+        const jumpHeight = 20;     // Разница высот, после которой бот прыгает
+        const jumpRange = 200;     // Горизонтальная дистанция, в пределах которой бот может прыгнуть
+        const stuckDistance = 1;   // Максимальное смещение, при котором бот считается неподвижным
+        const stuckTime = 500;     // Время (мс) без движения, после которого бот прыгает
+
         // --- Цвета ---
         const colors = { /* ... без изменений ... */
              backgroundStart: '#e0e6eb', backgroundEnd: '#b0b8c1', hillColorFar: 'rgba(130, 140, 150, 0.3)', hillColorNear: 'rgba(120, 130, 140, 0.4)', platformBase: '#f5d7a4', platformEdge: '#e4a76a', playerBody: '#2c3e50', player1Headband: '#3498db', player2Headband: '#e74c3c', eyeWhite: '#ffffff', eyePupil: '#000000', indicator: '#f1c40f', borderColor: '#f5c876', palmTrunk: '#a0795b', palmLeaves: '#27ae60', flash: 'rgba(255, 255, 0, 0.3)'
@@ -113,7 +120,12 @@ import { updateBotAI } from './botAI.js';
                     jumpStrength,
                     accelerationFactor,
                     decelerationFactor,
-                    jumpVelocityThreshold
+                    jumpVelocityThreshold,
+                    chaseDistance,
+                    jumpHeight,
+                    jumpRange,
+                    stuckDistance,
+                    stuckTime
                 }, dt);
             }
             Engine.update(engine, dt); updateCamera(camera, canvasWidth, canvasHeight, worldWidth, worldHeight, zoomPadding, minZoom, maxZoom, zoomLerpFactor, cameraLerpFactor, playerBodies);


### PR DESCRIPTION
## Summary
- parameterize bot AI constants for chase, jump and stuck logic
- pass new parameters from game setup to the bot AI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68444b3419408322998c92fa2637aa8f