### PR TITLE
Add platform graph and pathfinding for AI

### DIFF
--- a/botAI.js
+++ b/botAI.js
@@ -1,11 +1,16 @@
 import { Body } from './physics.js';
 import { applyMovement } from './movementController.js';
+import { getNearestPlatform, findPath } from './platformGraph.js';
 
-export function updateBotAI(botBody, playerBody, config, dt) {
+export function updateBotAI(botBody, playerBody, platformGraph, platformBodies, config, dt) {
     const { moveSpeed, jumpStrength, accelerationFactor, decelerationFactor, jumpVelocityThreshold } = config;
 
     if (!botBody.renderData.aiState) {
         botBody.renderData.aiState = {
+            lastPlatform: null,
+            targetPlatform: null,
+            path: [],
+            index: 0,
             lastPosX: botBody.position.x,
             stuckTime: Date.now()
         };
@@ -14,23 +19,63 @@ export function updateBotAI(botBody, playerBody, config, dt) {
     const ai = botBody.renderData.aiState;
     const now = Date.now();
 
+    const botPlatform = getNearestPlatform(botBody, platformBodies);
+    const playerPlatform = getNearestPlatform(playerBody, platformBodies);
+
+    if (!ai.path.length || ai.targetPlatform !== playerPlatform?.label || ai.lastPlatform !== botPlatform?.label) {
+        if (botPlatform && playerPlatform) {
+            const newPath = findPath(platformGraph, botPlatform.label, playerPlatform.label);
+            ai.path = newPath || [];
+            ai.index = 1;
+            ai.targetPlatform = playerPlatform.label;
+        }
+    }
+
+    ai.lastPlatform = botPlatform ? botPlatform.label : null;
+
     const input = { moveLeft: false, moveRight: false, jumpPressed: false };
 
-    const dx = playerBody.position.x - botBody.position.x;
-    const dy = playerBody.position.y - botBody.position.y;
+    let targetX = playerBody.position.x;
+    let nextPlatform = null;
 
+    if (ai.index < ai.path.length) {
+        const nextLabel = ai.path[ai.index];
+        nextPlatform = platformBodies.find(p => p.label === nextLabel);
+        if (nextPlatform) targetX = nextPlatform.position.x;
+    }
+
+    const dx = targetX - botBody.position.x;
     if (Math.abs(dx) > 2) {
         if (dx < 0) input.moveLeft = true;
         else input.moveRight = true;
     }
 
-    const horizontalDistance = Math.abs(dx);
-    const shouldJump = dy < -20 && horizontalDistance < 200;
+    if (nextPlatform && botPlatform) {
+        const verticalDiff = botPlatform.position.y - nextPlatform.position.y;
+        const horizontalDistance = Math.abs(dx);
+        if (verticalDiff > 20 && horizontalDistance < 220 && botBody.renderData.isOnGround && Math.abs(botBody.velocity.y) < jumpVelocityThreshold) {
+            input.jumpPressed = true;
+        }
 
-    const isStuck = (Math.abs(botBody.position.x - ai.lastPosX) < 1) && (now - ai.stuckTime > 500);
+        if (botPlatform.label === nextPlatform.label) {
+            ai.index += 1;
+        }
+    } else {
+        const dy = playerBody.position.y - botBody.position.y;
+        const horizontalDistance = Math.abs(dx);
+        const shouldJump = dy < -20 && horizontalDistance < 200;
+        if (shouldJump && botBody.renderData.isOnGround && Math.abs(botBody.velocity.y) < jumpVelocityThreshold) {
+            input.jumpPressed = true;
+        }
+    }
 
-    if ((shouldJump || isStuck) && botBody.renderData.isOnGround && Math.abs(botBody.velocity.y) < jumpVelocityThreshold) {
-        input.jumpPressed = true;
+    const isStuck = Math.abs(botBody.position.x - ai.lastPosX) < 1 && (now - ai.stuckTime > 500);
+    if (isStuck) {
+        ai.path = [];
+        ai.index = 0;
+        if (botBody.renderData.isOnGround && Math.abs(botBody.velocity.y) < jumpVelocityThreshold) {
+            input.jumpPressed = true;
+        }
         ai.stuckTime = now;
     }
 

--- a/platformGraph.js
+++ b/platformGraph.js
@@ -1,0 +1,68 @@
+export function buildPlatformGraph(platformBodies, maxHorizontal = 250, maxVertical = 220) {
+    const platforms = platformBodies.filter(p => p.label.startsWith('platform-'));
+    const graph = {};
+    platforms.forEach(a => {
+        graph[a.label] = [];
+        platforms.forEach(b => {
+            if (a === b) return;
+            const dx = Math.abs(b.position.x - a.position.x);
+            const dy = a.position.y - b.position.y;
+            const horizontalReach = maxHorizontal + a.renderData.width / 2 + b.renderData.width / 2;
+            if (dx <= horizontalReach) {
+                if (dy <= maxVertical) {
+                    graph[a.label].push(b.label);
+                } else if (dy < -maxVertical) {
+                    // allow drops to lower platforms within horizontal reach
+                    graph[a.label].push(b.label);
+                }
+            }
+        });
+    });
+    return graph;
+}
+
+export function getNearestPlatform(body, platformBodies) {
+    let best = null;
+    let bestDy = Infinity;
+    platformBodies.forEach(p => {
+        if (!p.label.startsWith('platform-')) return;
+        const halfWidth = p.renderData.width / 2;
+        const dx = Math.abs(body.position.x - p.position.x);
+        if (dx <= halfWidth + 20) {
+            const topY = p.position.y - p.renderData.height / 2;
+            const dy = topY - body.position.y;
+            if (dy >= -10 && dy < bestDy) {
+                bestDy = dy;
+                best = p;
+            }
+        }
+    });
+    return best;
+}
+
+export function findPath(graph, startLabel, goalLabel) {
+    if (!startLabel || !goalLabel) return null;
+    const queue = [startLabel];
+    const visited = new Set([startLabel]);
+    const prev = {};
+    while (queue.length) {
+        const current = queue.shift();
+        if (current === goalLabel) break;
+        const neighbors = graph[current] || [];
+        neighbors.forEach(n => {
+            if (!visited.has(n)) {
+                visited.add(n);
+                prev[n] = current;
+                queue.push(n);
+            }
+        });
+    }
+    if (!visited.has(goalLabel)) return null;
+    const path = [];
+    let cur = goalLabel;
+    while (cur) {
+        path.unshift(cur);
+        cur = prev[cur];
+    }
+    return path;
+}


### PR DESCRIPTION
## Summary
- implement `platformGraph.js` with graph building, path search and nearest platform helpers
- extend `botAI` with platform-aware navigation and stuck handling
- create platform graph in `game.js` and pass it into the AI update function

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845376fbc7883229efa03967dab8ce5