### PR TITLE
Implement navigation graph for smarter bot

### DIFF
--- a/botAI.js
+++ b/botAI.js
@@ -1,44 +1,127 @@
 import { Body } from './physics.js';
 import { applyMovement } from './movementController.js';
 
+let navigationGraph = [];
+let navConfig = { jumpHeight: 150, jumpReach: 260 };
+
+export function initBotNavigation(platformBodies, config) {
+    navConfig = { ...navConfig, ...config };
+    navigationGraph = platformBodies
+        .filter(p => p.label.startsWith('platform-') && p.label !== 'platform-ceiling')
+        .map((p, index) => ({
+            index,
+            x: p.position.x - p.renderData.width / 2,
+            y: p.position.y - p.renderData.height / 2,
+            width: p.renderData.width,
+            height: p.renderData.height,
+            neighbors: []
+        }));
+    linkPlatforms(navigationGraph, navConfig);
+}
+
+function linkPlatforms(graph, config) {
+    graph.forEach(platform => {
+        graph.forEach(other => {
+            if (platform === other) return;
+            const dx = Math.abs((platform.x + platform.width / 2) - (other.x + other.width / 2));
+            const dy = other.y - platform.y;
+            if (dx <= config.jumpReach && dy > -config.jumpHeight && dy < config.jumpHeight) {
+                platform.neighbors.push(other.index);
+            }
+        });
+    });
+}
+
+function findCurrentPlatform(body) {
+    return navigationGraph.find(p =>
+        body.position.x >= p.x &&
+        body.position.x <= p.x + p.width &&
+        body.position.y <= p.y + p.height &&
+        body.position.y >= p.y
+    );
+}
+
+function heuristic(a, b) {
+    return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+function findPath(graph, startIdx, goalIdx) {
+    const frontier = [{ idx: startIdx, cost: 0 }];
+    const cameFrom = {};
+    const costSoFar = {};
+    cameFrom[startIdx] = null;
+    costSoFar[startIdx] = 0;
+
+    while (frontier.length) {
+        frontier.sort((a, b) => a.cost - b.cost);
+        const current = frontier.shift().idx;
+        if (current === goalIdx) break;
+        graph[current].neighbors.forEach(nextIdx => {
+            const newCost = costSoFar[current] + heuristic(graph[current], graph[nextIdx]);
+            if (!(nextIdx in costSoFar) || newCost < costSoFar[nextIdx]) {
+                costSoFar[nextIdx] = newCost;
+                frontier.push({ idx: nextIdx, cost: newCost + heuristic(graph[nextIdx], graph[goalIdx]) });
+                cameFrom[nextIdx] = current;
+            }
+        });
+    }
+
+    let current = goalIdx;
+    const path = [];
+    while (current !== startIdx) {
+        path.unshift(current);
+        current = cameFrom[current];
+        if (current === null || current === undefined) return [];
+    }
+    return path;
+}
+
 export function updateBotAI(botBody, playerBody, config, dt) {
     const { moveSpeed, jumpStrength, accelerationFactor, decelerationFactor, jumpVelocityThreshold } = config;
 
     if (!botBody.renderData.aiState) {
         botBody.renderData.aiState = {
-            lastPosX: botBody.position.x,
-            stuckTime: Date.now()
+            lastPos: { x: botBody.position.x, y: botBody.position.y },
+            stuckTimer: 0
         };
     }
 
     const ai = botBody.renderData.aiState;
-    const now = Date.now();
-
     const input = { moveLeft: false, moveRight: false, jumpPressed: false };
 
-    const dx = playerBody.position.x - botBody.position.x;
-    const dy = playerBody.position.y - botBody.position.y;
+    const botPlatform = findCurrentPlatform(botBody);
+    const playerPlatform = findCurrentPlatform(playerBody);
 
-    if (Math.abs(dx) > 2) {
-        if (dx < 0) input.moveLeft = true;
-        else input.moveRight = true;
+    if (botPlatform && playerPlatform) {
+        if (botPlatform.index === playerPlatform.index) {
+            input.moveLeft = botBody.position.x > playerBody.position.x;
+            input.moveRight = botBody.position.x < playerBody.position.x;
+        } else {
+            const path = findPath(navigationGraph, botPlatform.index, playerPlatform.index);
+            if (path.length) {
+                const nextPlatform = navigationGraph[path[0]];
+                const targetX = nextPlatform.x + nextPlatform.width / 2;
+                input.moveLeft = botBody.position.x > targetX + 2;
+                input.moveRight = botBody.position.x < targetX - 2;
+                if (botBody.position.y > nextPlatform.y && botBody.renderData.isOnGround &&
+                    Math.abs(botBody.velocity.y) < jumpVelocityThreshold) {
+                    input.jumpPressed = true;
+                }
+            }
+        }
     }
 
-    const horizontalDistance = Math.abs(dx);
-    const shouldJump = dy < -20 && horizontalDistance < 200;
-
-    const isStuck = (Math.abs(botBody.position.x - ai.lastPosX) < 1) && (now - ai.stuckTime > 500);
-
-    if ((shouldJump || isStuck) && botBody.renderData.isOnGround && Math.abs(botBody.velocity.y) < jumpVelocityThreshold) {
+    const movedDist = Math.hypot(botBody.position.x - ai.lastPos.x, botBody.position.y - ai.lastPos.y);
+    if (movedDist < 1) {
+        ai.stuckTimer += dt;
+    } else {
+        ai.stuckTimer = 0;
+        ai.lastPos = { x: botBody.position.x, y: botBody.position.y };
+    }
+    if (ai.stuckTimer > 500 && botBody.renderData.isOnGround && Math.abs(botBody.velocity.y) < jumpVelocityThreshold) {
         input.jumpPressed = true;
-        ai.stuckTime = now;
+        ai.stuckTimer = 0;
     }
-
-    if (Math.abs(botBody.position.x - ai.lastPosX) >= 1) {
-        ai.stuckTime = now;
-    }
-
-    ai.lastPosX = botBody.position.x;
 
     applyMovement(
         botBody,

--- a/game.js
+++ b/game.js
@@ -3,7 +3,7 @@ import { initControls, handleInput } from './controls.js';
 import { Engine, World, Bodies, Body, initPhysics, setupCollisionEvents } from "./physics.js";
 import { drawParallaxBackground, drawPlatforms, drawDecorations, drawPlayer, drawFlash, updateCamera } from './render.js';
 import { initGame, isSinglePlayer } from './initGame.js';
-import { updateBotAI } from './botAI.js';
+import { updateBotAI, initBotNavigation } from './botAI.js';
 
     document.addEventListener('DOMContentLoaded', () => {
 
@@ -91,6 +91,7 @@ import { updateBotAI } from './botAI.js';
         const platformBodies = []; const platformOptions = { isStatic: true, friction: 0.5, frictionStatic: 0.8, restitution: 0 };
         platformData.forEach((data) => { const platformBody = Bodies.rectangle(data.x, data.y, data.width, data.height, { ...platformOptions, angle: data.angle, label: data.label }); platformBody.renderData = { width: data.width, height: data.height, colorBase: colors.platformBase, colorTop: colors.platformEdge, visible: data.visible !== false }; platformBodies.push(platformBody); });
         World.add(world, platformBodies);
+        initBotNavigation(platformBodies, { jumpHeight: 160, jumpReach: 300 });
         setupCollisionEvents({ engine, playerBodies, tagCooldownTime, groundCheckThreshold, jumpStrength, onTag: () => { flashOpacity = 0.3; console.log("Tag! Roles swapped. Flash activated."); } });
 
         // --- Декорации (без изменений) ---


### PR DESCRIPTION
## Summary
- add new navigation-graph driven AI
- build navigation graph on game start
- integrate pathfinding bot movement

## Testing
- `node --check botAI.js`
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_684540762d308322ad1ee760be792ea6